### PR TITLE
ID attribute in root mods element

### DIFF
--- a/eulxml/xmlmap/mods.py
+++ b/eulxml/xmlmap/mods.py
@@ -263,6 +263,7 @@ class BaseMods(Common):
     top-level MODS elements; base class for :class:`MODS` and :class:`RelatedItem`.'''
     schema_validate = True
 
+    id = xmlmap.StringField("@ID")
     title = xmlmap.StringField("mods:titleInfo/mods:title")
     title_info = xmlmap.NodeField('mods:titleInfo', TitleInfo)
     resource_type  = xmlmap.SchemaField("mods:typeOfResource", "resourceTypeDefinition")

--- a/test/test_xmlmap/test_mods.py
+++ b/test/test_xmlmap/test_mods.py
@@ -28,7 +28,7 @@ proxy_required = skipIf('HTTP_PROXY' not in os.environ,
 class TestMods(unittest.TestCase):
     # tests for MODS XmlObject
 
-    FIXTURE = """<mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
+    FIXTURE = """<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" ID="id1">
   <mods:titleInfo>
     <mods:title>A simple record</mods:title>
     <mods:subTitle> (for test purposes)</mods:subTitle>
@@ -100,6 +100,7 @@ class TestMods(unittest.TestCase):
         self.assert_(isinstance(self.mods.locations[0], mods.Location))
 
     def test_fields(self):
+        self.assertEqual('id1', self.mods.id)
         self.assertEqual('A simple record', self.mods.title)
         self.assertEqual('text', self.mods.resource_type)
         self.assertEqual('a general note', self.mods.note.label)


### PR DESCRIPTION
This commit adds the ID attribute to the root mods element. Unit test is included.
