### PR TITLE
add OrderedXmlObject whose constructor adds nodes in a specific order

### DIFF
--- a/eulxml/xmlmap/core.py
+++ b/eulxml/xmlmap/core.py
@@ -28,7 +28,8 @@ from eulxml.xmlmap.fields import Field
 logger = logging.getLogger(__name__)
 
 __all__ = ['XmlObject', 'parseUri', 'parseString', 'loadSchema',
-    'load_xmlobject_from_string', 'load_xmlobject_from_file']
+    'load_xmlobject_from_string', 'load_xmlobject_from_file',
+    'OrderedXmlObject']
 
 # NB: When parsing XML in this module, we explicitly create a new parser
 #   each time. Without this, lxml 2.2.7 uses a global default parser. When
@@ -524,6 +525,20 @@ class XmlObject(object):
         """
         return len(self.node) == 0 and len(self.node.attrib) == 0 \
             and not self.node.text and not self.node.tail  # regular text or text after a node
+
+
+class OrderedXmlObject(XmlObject):
+    ORDER = ()
+
+    def __init__(self, *args, **kwargs):
+        ordered_pairs = []
+        for attr in self.ORDER:
+            value = kwargs.pop(attr, None)
+            if value is not None:
+                ordered_pairs.append((attr, value))
+        super(OrderedXmlObject, self).__init__(*args, **kwargs)
+        for attr, value in ordered_pairs:
+            setattr(self, attr, value)
 
 
 class Urllib2Resolver(etree.Resolver):


### PR DESCRIPTION
This is very useful for having the mapper (your XmlObject subclass) control the order of its nodes, rather than push that out to the calling code. This comes up a lot in testing for example, where the XML-equal comparison enforces order, even if in your particular case the order isn't semantically meaningful.
