### PR TITLE
TypeError if SimpleBooleanField is absent

### DIFF
--- a/eulxml/xmlmap/fields.py
+++ b/eulxml/xmlmap/fields.py
@@ -142,9 +142,11 @@ class SimpleBooleanMapper(Mapper):
         self.false = false
 
     def to_python(self, node):
-        if node is None and \
-                self.false is None:
-            return False
+        if node is None:
+            if self.false is None:
+                return False
+            else:
+                return None
 
         if isinstance(node, basestring):
             value = node


### PR DESCRIPTION
In my project I read boolean fields from xml structures that have two states: *"true"* and *"false"*. These fields are optional in some cases, so they may be missed. 
And the most appropriate behaviour in such cases is to return *None* as *IntegerFields* do, but not to throw any exceptions.
Code to reproduce:
```python
import eulxml.xmlmap as xm

class Test1(xm.XmlObject):
    id = xm.IntegerField('id')
    flag = xm.SimpleBooleanField('flag', 'true', 'false')

xml1 = "<test> <id>1</id> <flag>true</flag> </test>"
xml2 = "<test> </test>"

o1 = xm.load_xmlobject_from_string(xml1, Test1)
o2 = xm.load_xmlobject_from_string(xml2, Test1)

# Fields are right
print "o1 id:", o1.id
print "o1 flag:", o1.flag

# No integer field in xml - ok, it will be None
print "o2 id:", o2.id
# No bool field in xml - bad, weird exception
try:
    print "o2 flag:", o2.flag
except TypeError as e:
    print "Here we got TypeError"
```
Expected:
```
o1 id: 1
o1 flag: True
o2 id: None
o2 flag: None
```
Actual:
```
o1 id: 1
o1 flag: True
o2 id: None
o2 flag: Here we got TypeError
```

BTW: eulxml is a great lib, helped a lot! :thumbsup: