### PR TITLE
Feature/multiple ids

### DIFF
--- a/eulxml/xmlmap/core.py
+++ b/eulxml/xmlmap/core.py
@@ -51,7 +51,7 @@ __all__ = ['XmlObject', 'parseUri', 'parseString', 'loadSchema',
 #   https://bugs.launchpad.net/lxml/+bug/673205
 
 
-    
+
 def parseUri(stream, uri=None):
     """Read an XML document from a URI, and return a :mod:`lxml.etree`
     document."""
@@ -552,7 +552,7 @@ class XmlObject(six.with_metaclass(XmlObjectType, object)):
 
 
 """ April 2016. Removing Urllib2Resolver so we can support
-  loading local copies of schema and skip validation in get_xml_parser """ 
+  loading local copies of schema and skip validation in get_xml_parser """
 
 
 def _get_xmlparser(xmlclass=XmlObject, validate=False, resolver=None):
@@ -575,8 +575,15 @@ def _get_xmlparser(xmlclass=XmlObject, validate=False, resolver=None):
             # if configured XmlObject does not have a schema defined, assume DTD validation
             opts = {'dtd_validation': True}
     else:
-        # if validation is not requested, no parser options are needed
-        opts = {}
+        # If validation is not requested, then the parsing should fail
+        # only for well-formedness issues.
+        #
+        # Therefore, we must turn off collect_ids, otherwise lxml will
+        # have a problem with duplicate IDs as it collects
+        # them. However, the XML spec declares ID uniqueness as a
+        # validation constraint, not a well-formedness
+        # constraint. (See https://www.w3.org/TR/xml/#id.)
+        opts = {"collect_ids": False}
 
     parser = etree.XMLParser(**opts)
 

--- a/eulxml/xmlmap/teimap.py
+++ b/eulxml/xmlmap/teimap.py
@@ -94,7 +94,7 @@ class TeiFigure(_TeiBase):
 class TeiInterp(_TeiBase):
     ROOT_NAME = 'interp'
     id          = xmlmap.StringField("@xml:id")
-    value       = xmlmap.StringField(".")
+    value       = xmlmap.StringField("@value")
 
 class TeiSection(_TeiBase):
     # top-level sections -- front/body/back

--- a/test/test_xmlmap/test_core.py
+++ b/test/test_xmlmap/test_core.py
@@ -187,10 +187,17 @@ class TestXmlObjectStringInit(unittest.TestCase):
 ]>
 <a><b/><b/></a>"""
 
+    # A document with duplicate IDs is well-formed but not valid. So
+    # it should load if validation is turned off.
+    DUPLICATE_IDS = """
+    <a xml:id="A"><b xml:id="A"/></a>
+    """
+
     def test_load_from_string(self):
         """Test using shortcut to initialize XmlObject from string"""
         obj = xmlmap.load_xmlobject_from_string(TestXsl.FIXTURE_TEXT)
         self.assert_(isinstance(obj, xmlmap.XmlObject))
+
 
     def test_load_from_string_with_classname(self):
         """Test using shortcut to initialize named XmlObject class from string"""
@@ -210,6 +217,20 @@ class TestXmlObjectStringInit(unittest.TestCase):
 
         obj = xmlmap.load_xmlobject_from_string(self.VALID_XML)
         self.assert_(isinstance(obj, xmlmap.XmlObject))
+
+    def test_load_from_string_with_duplicate_ids(self):
+        """
+        Test using shortcut to initialize XmlObject from string. When the
+        source has duplicate IDs.
+        """
+        self.assertRaises(etree.XMLSyntaxError,
+                          xmlmap.load_xmlobject_from_string,
+                          self.DUPLICATE_IDS, validate=True)
+
+        obj = xmlmap.load_xmlobject_from_string(self.DUPLICATE_IDS)
+        self.assert_(isinstance(obj, xmlmap.XmlObject))
+
+
 
 
 class TestXmlObjectFileInit(unittest.TestCase):
@@ -404,7 +425,7 @@ class TestXmlObject(unittest.TestCase):
 
 class TestLoadSchema(unittest.TestCase):
 
-    
+
     def test_load_schema(self):
         schema = xmlmap.loadSchema('http://www.w3.org/2001/xml.xsd')
         self.assert_(isinstance(schema, etree.XMLSchema),


### PR DESCRIPTION
This pull request turns off the `collect_ids` option of lxml when validation is not needed.

The fact that `xml:id` values must be unique in a document is a validation constraint, not a well-formedness constraint. (See https://www.w3.org/TR/xml/#id) However, even when validation is not needed, lxml will raise an error on duplicate `xml:id`s because lxml's `collect_ids` option is turned on by default. Effectively, this means that a well-formed document will fail to parse even if validation is not requested if it happens to have duplicate `xml:id` values.

The first commit fixes an issue with the tests that is unrelated to the main topic of this pull request but which prevented me from staring with a clean test run.

I ran into the problem I'm fixing here because one of my full-text eXist queries returned two documents that happened to have the same `xml:id` values. The two documents are *individually* well-formed and valid. They do not contain duplicate `xml:id` values. However, because they appear together as children of `exist:result`, they cause a parsing error with lxml for the reason described above. I'm working on an upcoming pull request to add a test to eulexistdb to cover this case.