### PR TITLE
Fix xml attribute set problem

### DIFF
--- a/eulxml/xmlmap/fields.py
+++ b/eulxml/xmlmap/fields.py
@@ -423,8 +423,7 @@ def _set_in_xml(node, val, context, step):
 
         # otherwise, treat it as an attribute
         else:
-            attribute, node_xpath, nsmap = _get_attribute_name(step, context)
-            node.getparent().set(attribute, val)
+            node.getparent().set(node.attrname, val)
 
 
 def _remove_xml(xast, node, context, if_empty=False):

--- a/test/test_xmlmap/test_fields.py
+++ b/test/test_xmlmap/test_fields.py
@@ -25,6 +25,25 @@ from six.moves.builtins import str as text
 import eulxml.xmlmap.core as xmlmap
 
 
+class TestAttributeSetRegression(unittest.TestCase):
+    def testTextField(self):
+        class TestObject(xmlmap.XmlObject):
+            baz_attr = xmlmap.StringField('/foo/bar/@baz')
+
+        FIXTURE_TEXT = """
+            <foo id='a' xmlns:ex='http://example.com/'>
+                <bar baz="foobar"/>
+            </foo>
+        """
+        url = '%s#%s.%s' % (__file__, self.__class__.__name__, 'FIXTURE_TEXT')
+        self.fixture = xmlmap.parseString(FIXTURE_TEXT, url)
+
+        obj = TestObject(self.fixture)
+        self.assertEqual(obj.baz_attr, "foobar")
+        obj.baz_attr = "barfoo"
+        self.assertEqual(obj.baz_attr, "barfoo")
+
+
 class TestFields(unittest.TestCase):
     FIXTURE_TEXT = '''
         <foo id='a' xmlns:ex='http://example.com/'>


### PR DESCRIPTION
With a fully qualified xpath StringField attribute, setting would result
in an exception.
Please see example in newly added test.