### PR TITLE
lexer: convert re.UNICODE to int

### DIFF
--- a/eulxml/xpath/core.py
+++ b/eulxml/xpath/core.py
@@ -26,6 +26,7 @@ eulxml.xpath, not directly from here."""
 
 from __future__ import unicode_literals
 import os
+import sys
 import re
 from ply import lex, yacc
 import tempfile
@@ -120,15 +121,20 @@ class LexerWrapper(lex.Lexer):
 # try again without lex table generation.
 lexdir = os.path.dirname(lexrules.__file__)
 lexer = None
+
+if sys.version_info >= (3,6,0):
+    reflags = int(re.UNICODE)
+else:
+    reflags = re.UNICODE
 try:
     lexer = lex.lex(module=lexrules, optimize=1, outputdir=lexdir,
-        reflags=re.UNICODE)
+        reflags=reflags)
 except IOError as e:
     import errno
     if e.errno != errno.EACCES:
         raise
 if lexer is None:
-    lexer = lex.lex(module=lexrules, reflags=re.UNICODE)
+    lexer = lex.lex(module=lexrules, reflags=reflags)
 # then dynamically rewrite the lexer class to use the wonky override logic
 # above
 lexer.__class__ = LexerWrapper


### PR DESCRIPTION
Since python 3.6, RegexFlags are instances of RegexFlag, not int.
Passing re.UNICODE directly to the lexer will result in the generated
lextab.py returning a SyntaxError.

RegexFlag instances need to be explicitely converted to int. This
solution does not break compatibility with previous previous versions of
python that already return int values.

fix #35
ref: https://docs.python.org/3/library/re.html#module-contents